### PR TITLE
Update TextEncodingHelper.cs

### DIFF
--- a/src/Id3.Net/Utils/TextEncodingHelper.cs
+++ b/src/Id3.Net/Utils/TextEncodingHelper.cs
@@ -47,6 +47,9 @@ namespace Id3
 
         internal static string GetString(byte[] bytes, int start, int count, Id3TextEncoding encodingType)
         {
+            if (bytes.Length == 0) 
+                return string.Empty;
+            
             Encoding encoding = GetEncoding(encodingType);
             string str = encoding.GetString(bytes, start, count);
 


### PR DESCRIPTION
Some of my songs are throwing an error on the method GetString because the method GetSplitStrings is calling it with an empty string array. I tried opening the same files on another ID3 programs and the files open just fine. While not sure why this is happening, preventing the method from processing the empty string mitigates the problem.
![image_2022-03-10_231953](https://user-images.githubusercontent.com/6624434/157771639-95b300db-7e47-4404-96a0-a6d55452d088.png)
